### PR TITLE
Updated installed name to remove year

### DIFF
--- a/templates/tableau-server-ubuntu.yaml
+++ b/templates/tableau-server-ubuntu.yaml
@@ -113,7 +113,7 @@ Parameters:
 Mappings:
   DefaultConfiguration:
     InstallationConfig:
-      TableauServerInstaller: https://s3-us-west-2.amazonaws.com/tableau-healthcare-quickstart/tableau-server-2018-2-2_amd64.deb
+      TableauServerInstaller: https://s3-us-west-2.amazonaws.com/tableau-healthcare-quickstart/tableau-server_amd64.deb
       AutomatedInstaller: https://s3-us-west-2.amazonaws.com/tableau-healthcare-quickstart/automated-installer.sh
     MachineConfiguration:
       SystemVolumeSize: 100


### PR DESCRIPTION
Installer will always point to latest release per https://www.tableau.com/support/releases/server

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
